### PR TITLE
Add switchable Events / fix typo in AddLog()

### DIFF
--- a/TestClients/MtApi5TestClient/ViewModel.cs
+++ b/TestClients/MtApi5TestClient/ViewModel.cs
@@ -1676,7 +1676,7 @@ namespace MtApi5TestClient
 
         private void _mtApiClient_OnLastTimeBar(object sender, Mt5TimeBarArgs e)
         {
-            AddLog($"OnBookEvent: ExpertHandle = {e.ExpertHandle}, Symbol = {e.Symbol}, open = {e.Rates.open}, close = {e.Rates.close}, time = {e.Rates.time}, high = {e.Rates.high}, low = {e.Rates.low}");
+            AddLog($"OnLastTimeBarEvent: ExpertHandle = {e.ExpertHandle}, Symbol = {e.Symbol}, open = {e.Rates.open}, close = {e.Rates.close}, time = {e.Rates.time}, high = {e.Rates.high}, low = {e.Rates.low}");
         }
 
         private void _mtApiClient_OnLockTicks(object sender, Mt5LockTicksEventArgs e)


### PR DESCRIPTION
The function SendMtEvent requires a lot of computing time. To improve the speed of the tester, the events can now be switched off individually

#144 