### PR TITLE
Ported MtApi5 to .Net Core

### DIFF
--- a/MetaTraderApi_2017.sln
+++ b/MetaTraderApi_2017.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApiClientUI", "TestClients\TestApiClientUI\TestApiClientUI.csproj", "{663CC515-EAAE-47D4-8933-5008C2DA1160}"
 EndProject
@@ -46,6 +46,8 @@ Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "MtApiBootstrapper", "MtApiB
 	ProjectSection(ProjectDependencies) = postProject
 		{78B94552-DB17-40EC-B7C6-23D32DB85DC1} = {78B94552-DB17-40EC-B7C6-23D32DB85DC1}
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MtApiServiceNetCore", "MtApiServiceNetCore\MtApiServiceNetCore.csproj", "{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -232,6 +234,22 @@ Global
 		{8E63046B-56E5-4623-8808-558AD72A8F2B}.Release|x64.ActiveCfg = Release|x86
 		{8E63046B-56E5-4623-8808-558AD72A8F2B}.Release|x86.ActiveCfg = Release|x86
 		{8E63046B-56E5-4623-8808-558AD72A8F2B}.Release|x86.Build.0 = Release|x86
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Debug|Win32.Build.0 = Debug|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Debug|x64.Build.0 = Debug|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Debug|x86.Build.0 = Debug|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Release|Win32.ActiveCfg = Release|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Release|Win32.Build.0 = Release|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Release|x64.ActiveCfg = Release|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Release|x64.Build.0 = Release|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Release|x86.ActiveCfg = Release|Any CPU
+		{7CAFAAE2-0C15-479A-B16D-C2FCE0A48E11}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -240,5 +258,8 @@ Global
 		{663CC515-EAAE-47D4-8933-5008C2DA1160} = {B91FF338-E05D-4EF1-948B-A2376DB37ECA}
 		{38B9C657-BC2F-44F0-8824-54B31F2A64F5} = {B91FF338-E05D-4EF1-948B-A2376DB37ECA}
 		{EB7C228D-9494-4985-845E-B8312450DF3D} = {B91FF338-E05D-4EF1-948B-A2376DB37ECA}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {23C8878C-16A5-47DF-9A57-73CCF847780D}
 	EndGlobalSection
 EndGlobal

--- a/MtApi5/MtApi5.csproj
+++ b/MtApi5/MtApi5.csproj
@@ -1,120 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{AC8B5010-DA75-477E-9CA5-547C649E12D8}</ProjectGuid>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MtApi5</RootNamespace>
-    <AssemblyName>MtApi5</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>..\build\products\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>..\build\products\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration.Install" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\MtApiServiceNetCore\MtApiServiceNetCore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CopyTicksFlag.cs" />
-    <Compile Include="Events\OnBookEvent.cs" />
-    <Compile Include="Events\OnLastTimeBarEvent.cs" />
-    <Compile Include="Events\OnLockTicksEvent.cs" />
-    <Compile Include="Events\OnTickEvent.cs" />
-    <Compile Include="Events\OnTradeTransactionEvent.cs" />
-    <Compile Include="Mt5LockTicksEventArgs.cs" />
-    <Compile Include="Mt5TimeBarArgs.cs" />
-    <Compile Include="MqlBookInfo.cs" />
-    <Compile Include="MqlParam.cs" />
-    <Compile Include="MqlRates.cs" />
-    <Compile Include="MqlTick.cs" />
-    <Compile Include="MqlTradeCheckResult.cs" />
-    <Compile Include="MqlTradeTransaction.cs" />
-    <Compile Include="Mt5BookEventArgs.cs" />
-    <Compile Include="Mt5TimeConverter.cs" />
-    <Compile Include="Mt5Enums.cs" />
-    <Compile Include="Mt5ConnectionEventArgs.cs" />
-    <Compile Include="Mt5ConnectionState.cs" />
-    <Compile Include="MqlTradeRequest.cs" />
-    <Compile Include="MqlTradeResult.cs" />
-    <Compile Include="Mt5QuoteEventArgs.cs" />
-    <Compile Include="Mt5TradeTransactionEventArgs.cs" />
-    <Compile Include="MtApi5Client.cs" />
-    <Compile Include="Mt5CommandType.cs" />
-    <Compile Include="MtConverters.cs" />
-    <Compile Include="ErrorCode.cs" />
-    <Compile Include="ExecutionException.cs" />
-    <Compile Include="Events\Mt5EventTypes.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Mt5Quote.cs" />
-    <Compile Include="Requests\ChartTimePriceToXyRequest.cs" />
-    <Compile Include="Requests\ChartTimePriceToXyResult.cs" />
-    <Compile Include="Requests\ChartXyToTimePriceRequest.cs" />
-    <Compile Include="Requests\ChartXyToTimePriceResult.cs" />
-    <Compile Include="Requests\CopyTicksRequest.cs" />
-    <Compile Include="Requests\ICustomRequest.cs" />
-    <Compile Include="Requests\IndicatorCreateRequest.cs" />
-    <Compile Include="Requests\MarketBookGetRequest.cs" />
-    <Compile Include="Requests\OrderCheckRequest.cs" />
-    <Compile Include="Requests\OrderCheckResult.cs" />
-    <Compile Include="Requests\OrderSendRequest.cs" />
-    <Compile Include="Requests\PositionCloseRequest.cs" />
-    <Compile Include="Requests\PositionCloseResult.cs" />
-    <Compile Include="Requests\PositionOpenRequest.cs" />
-    <Compile Include="Requests\RequestBase.cs" />
-    <Compile Include="Requests\RequestType.cs" />
-    <Compile Include="Requests\OrderSendResult.cs" />
-    <Compile Include="Requests\Response.cs" />
-    <Compile Include="Requests\SymbolInfoStringRequest.cs" />
-    <Compile Include="Requests\SymbolInfoStringResult.cs" />
-    <Compile Include="Requests\SymbolInfoTickRequest.cs" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\MTApiService\MTApiService.csproj">
-      <Project>{DE76D5C7-B99C-4467-8408-78173BDD84E0}</Project>
-      <Name>MTApiService</Name>
-    </ProjectReference>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/MtApi5/packages.config
+++ b/MtApi5/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
 </packages>

--- a/MtApiServiceNetCore/MtApiProxy.cs
+++ b/MtApiServiceNetCore/MtApiProxy.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace MTApiService
+{
+    internal class MtApiProxy : IMtApi, IDisposable
+    {
+        private IMtApi InnerChannel;
+
+        public CommunicationState State => ((ICommunicationObject)InnerChannel).State;
+
+        public MtApiProxy(InstanceContext callbackContext, Binding binding, EndpointAddress remoteAddress)
+        {
+            var channel = new DuplexChannelFactory<IMtApi>(callbackContext, binding, remoteAddress);
+            channel.Faulted += InnerDuplexChannel_Faulted;
+
+            // configure endpoint programmatically instead via an attribute which will lead to a PlatformNotSupportedException
+            (channel.Endpoint.EndpointBehaviors.Single(b => b is CallbackBehaviorAttribute) as CallbackBehaviorAttribute).UseSynchronizationContext = false;
+
+            InnerChannel = channel.CreateChannel();
+        }
+
+        #region IMtApi Members
+
+        public bool Connect()
+        {
+            return InnerChannel.Connect();
+        }
+
+        public void Disconnect()
+        {
+            InnerChannel.Disconnect();
+        }
+
+        public MtResponse SendCommand(MtCommand command)
+        {
+            return InnerChannel.SendCommand(command);
+        }
+
+        public List<MtQuote> GetQuotes()
+        {
+            return InnerChannel.GetQuotes();
+        }
+
+        #endregion
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            try
+            {
+                Disconnect();
+            }
+            catch (Exception)
+            {
+
+            }
+        }
+
+        #endregion
+
+        #region Private Methods
+        private void InnerDuplexChannel_Faulted(object sender, EventArgs e)
+        {
+            Faulted?.Invoke(this, e);
+        }
+
+        #endregion
+
+        #region Events
+        public event EventHandler Faulted;
+        #endregion
+    }
+}

--- a/MtApiServiceNetCore/MtApiServiceNetCore.csproj
+++ b/MtApiServiceNetCore/MtApiServiceNetCore.csproj
@@ -1,0 +1,45 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\build\products\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>..\build\products\Release\</OutputPath>
+    <DefineConstants></DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile></AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\MTApiService\IMetaTraderHandler.cs" Link="IMetaTraderHandler.cs" />
+    <Compile Include="..\MTApiService\ITaskExecutor.cs" Link="ITaskExecutor.cs" />
+    <Compile Include="..\MTApiService\LogConfigurator.cs" Link="LogConfigurator.cs" />
+    <Compile Include="..\MTApiService\Mt5Expert.cs" Link="Mt5Expert.cs" />
+    <Compile Include="..\MTApiService\MtCommand.cs" Link="MtCommand.cs" />
+    <Compile Include="..\MTApiService\MtCommandEventArgs.cs" Link="MtCommandEventArgs.cs" />
+    <Compile Include="..\MTApiService\MtCommandTask.cs" Link="MtCommandTask.cs" />
+    <Compile Include="..\MTApiService\MtEvent.cs" Link="MtEvent.cs" />
+    <Compile Include="..\MTApiService\MtExpert.cs" Link="MtExpert.cs" />
+    <Compile Include="..\MTApiService\MtMqlRates.cs" Link="MtMqlRates.cs" />
+    <Compile Include="..\MTApiService\MtMqlTradeRequest.cs" Link="MtMqlTradeRequest.cs" />
+    <Compile Include="..\MTApiService\MtQuote.cs" Link="MtQuote.cs" />
+    <Compile Include="..\MTApiService\MtResponse.cs" Link="MtResponse.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.ServiceModel" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.7.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.7.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
+  </ItemGroup>
+  <PropertyGroup />
+</Project>

--- a/MtApiServiceNetCore/MtClient.cs
+++ b/MtApiServiceNetCore/MtClient.cs
@@ -1,0 +1,291 @@
+﻿using System;
+using System.Collections;
+using System.ServiceModel;
+using System.Collections.Generic;
+using log4net;
+using System.Threading.Tasks;
+
+namespace MTApiService
+{
+    public sealed class MtClient : IMtApiCallback, IDisposable
+    {
+        private const string ServiceName = "MtApiService";
+
+        public delegate void MtQuoteHandler(MtQuote quote);
+        public delegate void MtEventHandler(MtEvent e);
+
+        #region Fields
+        private static readonly ILog Log = LogManager.GetLogger(typeof(MtClient));
+
+        private readonly MtApiProxy _proxy;
+        private Task lastQuoteTask;
+        private Task lastEventTask;
+        #endregion
+
+        #region ctor
+        public MtClient(string host, int port)
+        {
+            if (string.IsNullOrEmpty(host))
+                throw new ArgumentNullException(nameof(host), "host is null or empty");
+
+            if (port < 0 || port > 65536)
+                throw new ArgumentOutOfRangeException(nameof(port), "port value is invalid");
+
+            Host = host;
+            Port = port;
+
+            var urlService = $"net.tcp://{host}:{port}/{ServiceName}";
+
+            var bind = new NetTcpBinding(SecurityMode.None)
+            {
+                MaxReceivedMessageSize = 2147483647,
+                MaxBufferSize = 2147483647,
+                MaxBufferPoolSize = 2147483647,
+                SendTimeout = new TimeSpan(12, 0, 0),
+                ReceiveTimeout = new TimeSpan(12, 0, 0),
+                ReaderQuotas =
+                {
+                    MaxArrayLength = 2147483647,
+                    MaxBytesPerRead = 2147483647,
+                    MaxDepth = 2147483647,
+                    MaxStringContentLength = 2147483647,
+                    MaxNameTableCharCount = 2147483647
+                }
+            };
+
+            var quoteScheduler = new TaskFactory(TaskCreationOptions.AttachedToParent, TaskContinuationOptions.AttachedToParent);
+            var eventScheduler = new TaskFactory(TaskCreationOptions.AttachedToParent, TaskContinuationOptions.AttachedToParent);
+            lastQuoteTask = quoteScheduler.StartNew(() => { });
+            lastEventTask = eventScheduler.StartNew(() => { });
+
+            _proxy = new MtApiProxy(new InstanceContext(this), bind, new EndpointAddress(urlService));
+            _proxy.Faulted += ProxyFaulted;
+        }
+
+        public MtClient(int port) : this("localhost", port)
+        { }
+
+        #endregion
+
+        #region Public Methods
+        /// <exception cref="CommunicationException">Thrown when connection failed</exception>
+        public void Connect()
+        {
+            Log.Debug("Connect: begin.");
+
+            if (_proxy.State != CommunicationState.Created)
+            {
+                Log.ErrorFormat("Connected: end. Client has invalid state {0}", _proxy.State);
+                return;
+            }
+
+            bool coonected;
+
+            try
+            {
+                coonected = _proxy.Connect();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorFormat("Connect: Exception - {0}", ex.Message);
+
+                throw new CommunicationException($"Connection failed to service. {ex.Message}");
+            }
+
+            if (coonected == false)
+            {
+                Log.Error("Connect: end. Connection failed.");
+                throw new CommunicationException("Connection failed");
+            }
+
+            Log.Debug("Connect: end.");
+        }
+
+        public void Disconnect()
+        {
+            Log.Debug("Disconnect: begin.");
+
+            try
+            {
+                _proxy.Disconnect();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorFormat("Disconnect: Exception - {0}", ex.Message);
+            }
+
+            Log.Debug("Disconnect: end.");
+        }
+
+        /// <exception cref="CommunicationException">Thrown when connection failed</exception>
+        public MtResponse SendCommand(int commandType, ArrayList parameters, Dictionary<string, object> namedParams, int expertHandle)
+        {
+            Log.DebugFormat("SendCommand: begin. commandType = {0}, parameters count = {1}", commandType, parameters?.Count);
+
+            if (IsConnected == false)
+            {
+                Log.Error("SendCommand: Client is not connected.");
+                throw new CommunicationException("Client is not connected.");
+            }
+
+            MtResponse result;
+
+            try
+            {
+                result = _proxy.SendCommand(new MtCommand {
+                    CommandType = commandType,
+                    Parameters = parameters,
+                    NamedParams = namedParams,
+                    ExpertHandle = expertHandle});
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorFormat("SendCommand: Exception - {0}", ex.Message);
+
+                throw new CommunicationException("Service connection failed! " + ex.Message);
+            }
+
+            Log.DebugFormat("SendCommand: end. result = {0}", result);
+
+            return result;
+        }
+
+        /// <exception cref="CommunicationException">Thrown when connection failed</exception>
+        public List<MtQuote> GetQuotes()
+        {
+            Log.Debug("GetQuotes: begin.");
+
+            if (IsConnected == false)
+            {
+                Log.Warn("GetQuotes: end. Client is not connected.");
+                return null;
+            }
+
+            List<MtQuote> result;
+
+            try
+            {
+                result = _proxy.GetQuotes();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorFormat("GetQuotes: Exception - {0}", ex.Message);
+
+                throw new CommunicationException($"Service connection failed! {ex.Message}");
+            }
+
+            Log.DebugFormat("GetQuotes: end. quotes count = {0}", result?.Count);
+
+            return result;
+        }
+
+        #endregion
+
+        #region IMtApiCallback Members
+
+        public void OnQuoteUpdate(MtQuote quote)
+        {
+            Log.DebugFormat("OnQuoteUpdate: begin. quote = {0}", quote);
+
+            if (quote == null) return;
+
+            if (QuoteUpdated != null)
+            {
+                lastQuoteTask = lastQuoteTask.ContinueWith((t) => QuoteUpdated.Invoke(quote));
+            }
+
+            Log.Debug("OnQuoteUpdate: end.");
+        }
+
+        public void OnQuoteAdded(MtQuote quote)
+        {
+            Log.DebugFormat("OnQuoteAdded: begin. quote = {0}", quote);
+
+            if (QuoteAdded != null)
+            {
+                lastQuoteTask = lastQuoteTask.ContinueWith((t) => QuoteAdded.Invoke(quote));
+            }
+
+            Log.Debug("OnQuoteAdded: end.");
+        }
+
+        public void OnQuoteRemoved(MtQuote quote)
+        {
+            Log.DebugFormat("OnQuoteRemoved: begin. quote = {0}", quote);
+
+            if (QuoteRemoved != null)
+            {
+                lastQuoteTask = lastQuoteTask.ContinueWith((t) => QuoteRemoved.Invoke(quote));
+            }
+
+            Log.Debug("OnQuoteRemoved: end.");
+        }
+
+        public void OnServerStopped()
+        {
+            Log.Debug("OnServerStopped: begin.");
+
+            ServerDisconnected?.Invoke(this, EventArgs.Empty);
+
+            Log.Debug("OnServerStopped: end.");
+        }
+
+
+        public void OnMtEvent(MtEvent e)
+        {
+            Log.DebugFormat("OnMtEvent: begin. event = {0}", e);
+
+            if (MtEventReceived != null)
+            {
+                lastEventTask = lastEventTask.ContinueWith((t) => MtEventReceived.Invoke(e));
+            }
+
+            Log.Debug("OnMtEvent: end.");
+        }
+
+        #endregion
+
+        #region Properties
+        public string Host { get; private set; }
+        public int Port { get; private set; }
+
+        private bool IsConnected => _proxy.State == CommunicationState.Opened;
+
+        #endregion
+
+        #region Private Methods
+
+        private void ProxyFaulted(object sender, EventArgs e)
+        {
+            Log.Debug("ProxyFaulted: begin.");
+
+            ServerFailed?.Invoke(this, EventArgs.Empty);
+
+            Log.Debug("ProxyFaulted: end.");
+        }
+
+        #endregion
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            Log.Debug("Dispose: begin.");
+
+            _proxy.Dispose();
+
+            Log.Debug("Dispose: end.");
+        }
+
+        #endregion
+
+        #region Events
+        public event MtQuoteHandler QuoteAdded;
+        public event MtQuoteHandler QuoteRemoved;
+        public event MtQuoteHandler QuoteUpdated;
+        public event EventHandler ServerDisconnected;
+        public event EventHandler ServerFailed;
+        public event MtEventHandler MtEventReceived;
+        #endregion
+    }
+}

--- a/MtApiServiceNetCore/MtService.cs
+++ b/MtApiServiceNetCore/MtService.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Threading;
+using log4net;
+
+namespace MTApiService
+{
+    [ServiceContract(CallbackContract = typeof(IMtApiCallback), SessionMode = SessionMode.Required)]
+    public interface IMtApi
+    {
+        [OperationContract]
+        bool Connect();
+
+        [OperationContract(IsOneWay = true)]
+        void Disconnect();
+
+        [OperationContract]
+        MtResponse SendCommand(MtCommand command);
+
+        [OperationContract]
+        List<MtQuote> GetQuotes();
+    }
+
+    [ServiceContract]
+    public interface IMtApiCallback
+    {
+        [OperationContract(IsOneWay = true)]
+        void OnQuoteUpdate(MtQuote quote);
+
+        [OperationContract(IsOneWay = true)]
+        void OnServerStopped();
+
+        [OperationContract(IsOneWay = true)]
+        void OnQuoteAdded(MtQuote quote);
+
+        [OperationContract(IsOneWay = true)]
+        void OnQuoteRemoved(MtQuote quote);
+
+        [OperationContract(IsOneWay = true)]
+        void OnMtEvent(MtEvent ntEvent);
+    }
+}

--- a/MtApiServiceNetCore/Properties/AssemblyInfo.cs
+++ b/MtApiServiceNetCore/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MTApiService")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("DW")]
+[assembly: AssemblyProduct("MTApiService")]
+[assembly: AssemblyCopyright("Copyright © DW 2011")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f1cc1516-9352-4ddd-811a-c5fc842b12d4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.32.0")]
+[assembly: AssemblyFileVersion("1.0.32.0")]

--- a/TestClients/MtApi5TestClient/MtApi5TestClient.csproj
+++ b/TestClients/MtApi5TestClient/MtApi5TestClient.csproj
@@ -1,154 +1,62 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{38B9C657-BC2F-44F0-8824-54B31F2A64F5}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MtApi5TestClient</RootNamespace>
-    <AssemblyName>MtApi5TestClient</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWpf>true</UseWpf>
+    <UseWindowsForms>false</UseWindowsForms>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeAnalysisLogFile>bin\Debug\MtApi5TestClient.exe.CodeAnalysisLog.xml</CodeAnalysisLogFile>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeAnalysisLogFile>bin\Release\MtApi5TestClient.exe.CodeAnalysisLog.xml</CodeAnalysisLogFile>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="DelegateCommand.cs" />
-    <Compile Include="ListBoxBehavior.cs" />
-    <Compile Include="MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="MqlTradeRequestViewModel.cs" />
-    <Compile Include="QuoteViewModel.cs" />
-    <Compile Include="TimeSeriesValueViewModel.cs" />
-    <Compile Include="ViewModel.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
+    <Compile Update="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
+    <Compile Update="Properties\Settings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
+    <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="app.config" />
-    <None Include="Properties\Settings.settings">
+    <None Update="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <AppDesigner Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\MtApi5\MtApi5.csproj">
-      <Project>{AC8B5010-DA75-477E-9CA5-547C649E12D8}</Project>
-      <Name>MtApi5</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\MtApi5\MtApi5.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+  </ItemGroup>
 </Project>

--- a/TestClients/MtApi5TestClient/Properties/Resources.Designer.cs
+++ b/TestClients/MtApi5TestClient/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace MtApi5TestClient.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/TestClients/MtApi5TestClient/Properties/Settings.Designer.cs
+++ b/TestClients/MtApi5TestClient/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MtApi5TestClient.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/TestClients/MtApi5TestClient/app.config
+++ b/TestClients/MtApi5TestClient/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>


### PR DESCRIPTION
This PR will add support for .Net Core on the client side (for MtApi5) as requested in #134. Contract files are linked from `MtApiService` to prevent duplicated code. Only duplicated some files due to required changes (unsupported functionality of the doftnet/wcf dependencies).

* added .net core based `MtApiService` (`MtApiServiceNetCore`)
* based on https://github.com/dotnet/wcf
* only client side is available in .Net Core
* piping removed, only tcp connection possible
* ported MtApi5 and MtApi5TestClient to .Net Core