### PR TITLE
Fix: error-checking condition was inverted.

### DIFF
--- a/mq4/MtApi.mq4
+++ b/mq4/MtApi.mq4
@@ -2945,7 +2945,7 @@ void Execute_iBandsOnArray()
    }
 
    param_index++;
-   if (getIntValue(ExpertHandle, param_index, total, _error))
+   if (!getIntValue(ExpertHandle, param_index, total, _error))
    {
       PrintParamError("iBandsOnArray", "total", _error);
       sendErrorResponse(ExpertHandle, -1, _error, _response_error);


### PR DESCRIPTION
Similar to previously fix on Ln 5359 in void Execute_SymbolInfoString() by hectorli #173 update IF checking (commit 26de553 on 27 Aug 2019), same error-checking condition was also inverted in Ln 2948 in void Execute_iBandsOnArray().