### PR TITLE
Update LogConfigurator.cs

### DIFF
--- a/MTApiService/LogConfigurator.cs
+++ b/MTApiService/LogConfigurator.cs
@@ -90,7 +90,8 @@ namespace MTApiService
             };
             patternLayout.ActivateOptions();
 
-            var filename = $"{DateTime.Now:yyyy-dd-M--HH-mm-ss}-{Process.GetCurrentProcess().Id}.{LogFileNameExtension}";
+            //var filename = $"{DateTime.Now:yyyy-dd-M--HH-mm-ss}-{Process.GetCurrentProcess().Id}.{LogFileNameExtension}";  // This filename format keeps generating tons of log files with same content but different per-second/thread filenames until the harddisk have 0KB space left
+            var filename = $"{DateTime.Now:yyyy-MM-dd}.{LogFileNameExtension}";
 
             var roller = new RollingFileAppender
             {


### PR DESCRIPTION
The part of filename "{DateTime.Now:yyyy-dd-M--HH-mm-ss}-{Process.GetCurrentProcess().Id}" generates tons of log files with same content but different per-second/thread filenames until the harddisk have 0KB space left. This kept happening in my AWS EC2 machine until I found the big GBs-size log file in temp folder caused by this line.

Changing the filename to $"{DateTime.Now:yyyy-MM-dd}.{LogFileNameExtension}" solved the issue. The timestamp and processId can still be found in the log content.