### PR TITLE
MtClient/MtApi5: async command API with request pipelining

### DIFF
--- a/MtApi5/MtApi5Client.cs
+++ b/MtApi5/MtApi5Client.cs
@@ -383,6 +383,14 @@ namespace MtApi5
         }
 
         ///<summary>
+        ///Asynchronous variant of PositionsTotal; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        public Task<int> PositionsTotalAsync()
+        {
+            return SendCommandAsync<int>(ExecutorHandle, Mt5CommandType.PositionsTotal);
+        }
+
+        ///<summary>
         ///Returns the symbol corresponding to the open position and automatically selects the position for further working with it using functions PositionGetDouble, PositionGetInteger, PositionGetString.
         ///</summary>
         ///<param name="index">Number of the position in the list of open positions.</param>
@@ -458,6 +466,14 @@ namespace MtApi5
         public int OrdersTotal()
         {
             return SendCommand<int>(ExecutorHandle, Mt5CommandType.OrdersTotal);
+        }
+
+        ///<summary>
+        ///Asynchronous variant of OrdersTotal; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        public Task<int> OrdersTotalAsync()
+        {
+            return SendCommandAsync<int>(ExecutorHandle, Mt5CommandType.OrdersTotal);
         }
 
         ///<summary>
@@ -875,6 +891,16 @@ namespace MtApi5
         }
 
         ///<summary>
+        ///Asynchronous variant of AccountInfoDouble; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="propertyId">Identifier of the property.</param>
+        public Task<double> AccountInfoDoubleAsync(ENUM_ACCOUNT_INFO_DOUBLE propertyId)
+        {
+            Dictionary<string, object> cmdParams = new() { { "PropertyId", propertyId } };
+            return SendCommandAsync<double>(ExecutorHandle, Mt5CommandType.AccountInfoDouble, cmdParams);
+        }
+
+        ///<summary>
         ///Returns the value of the corresponding account property. 
         ///</summary>
         ///<param name="propertyId">Identifier of the property.</param>
@@ -882,6 +908,16 @@ namespace MtApi5
         {
             Dictionary<string, object> cmdParams = new() { { "PropertyId", propertyId } };
             return SendCommand<long>(ExecutorHandle, Mt5CommandType.AccountInfoInteger, cmdParams);
+        }
+
+        ///<summary>
+        ///Asynchronous variant of AccountInfoInteger; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="propertyId">Identifier of the property.</param>
+        public Task<long> AccountInfoIntegerAsync(ENUM_ACCOUNT_INFO_INTEGER propertyId)
+        {
+            Dictionary<string, object> cmdParams = new() { { "PropertyId", propertyId } };
+            return SendCommandAsync<long>(ExecutorHandle, Mt5CommandType.AccountInfoInteger, cmdParams);
         }
 
         ///<summary>
@@ -1013,7 +1049,22 @@ namespace MtApi5
             ratesArray = response?.ToArray() ?? [];
             return response?.Count ?? 0;
         }
-            
+
+        ///<summary>
+        ///Asynchronous variant of CopyRates; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="symbolName">Symbol name.</param>
+        ///<param name="timeframe">Period.</param>
+        ///<param name="startPos">The start position for the first element to copy.</param>
+        ///<param name="count">Data count to copy.</param>
+        public async Task<MqlRates[]?> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, int startPos, int count)
+        {
+            Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "Timeframe", (int)timeframe },
+                { "StartPos", startPos }, { "Count", count } };
+            var response = await SendCommandAsync<List<MqlRates>>(ExecutorHandle, Mt5CommandType.CopyRates, cmdParams).ConfigureAwait(false);
+            return response?.ToArray();
+        }
+
         ///<summary>
         ///Gets history data of MqlRates structure of a specified symbol-period in specified quantity into the ratesArray array. The elements ordering of the copied data is from present to the past, i.e., starting position of 0 means the current bar.
         ///</summary>
@@ -1032,6 +1083,21 @@ namespace MtApi5
         }
 
         ///<summary>
+        ///Asynchronous variant of CopyRates; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="symbolName">Symbol name.</param>
+        ///<param name="timeframe">Period.</param>
+        ///<param name="startTime">The start time for the first element to copy.</param>
+        ///<param name="count">Data count to copy.</param>
+        public async Task<MqlRates[]?> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, DateTime startTime, int count)
+        {
+            Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "Timeframe", (int)timeframe },
+                { "StartTime",  Mt5TimeConverter.ConvertToMtTime(startTime) }, { "Count", count } };
+            var response = await SendCommandAsync<List<MqlRates>>(ExecutorHandle, Mt5CommandType.CopyRates1, cmdParams).ConfigureAwait(false);
+            return response?.ToArray();
+        }
+
+        ///<summary>
         ///Gets history data of MqlRates structure of a specified symbol-period in specified quantity into the ratesArray array. The elements ordering of the copied data is from present to the past, i.e., starting position of 0 means the current bar.
         ///</summary>
         ///<param name="symbolName">Symbol name.</param>
@@ -1047,6 +1113,22 @@ namespace MtApi5
             var response = SendCommand<List<MqlRates>>(ExecutorHandle, Mt5CommandType.CopyRates2, cmdParams);
             ratesArray = response?.ToArray() ?? [];
             return response?.Count ?? 0;
+        }
+
+        ///<summary>
+        ///Asynchronous variant of CopyRates; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="symbolName">Symbol name.</param>
+        ///<param name="timeframe">Period.</param>
+        ///<param name="startTime">The start time for the first element to copy.</param>
+        ///<param name="stopTime">Bar time, corresponding to the last element to copy.</param>
+        public async Task<MqlRates[]?> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, DateTime startTime, DateTime stopTime)
+        {
+            Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "Timeframe", (int)timeframe },
+                { "StartTime",  Mt5TimeConverter.ConvertToMtTime(startTime) },
+                { "StopTime", Mt5TimeConverter.ConvertToMtTime(stopTime) } };
+            var response = await SendCommandAsync<List<MqlRates>>(ExecutorHandle, Mt5CommandType.CopyRates2, cmdParams).ConfigureAwait(false);
+            return response?.ToArray();
         }
 
         ///<summary>
@@ -1505,6 +1587,22 @@ namespace MtApi5
         }
 
         ///<summary>
+        ///Asynchronous variant of CopyTicks; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="symbolName">Symbol name.</param>
+        ///<param name="flags">The flag that determines the type of received ticks.</param>
+        ///<param name="from">The date from which you want to request ticks.  In milliseconds since 1970.01.01. If from=0, the last count ticks will be returned.</param>
+        ///<param name="count">The number of ticks that you want to receive. If the 'from' and 'count' parameters are not specified, all available recent ticks (but not more than 2000) will be written to result.</param>
+        ///<see href="https://www.mql5.com/en/docs/series/copyticks"/>
+        public async Task<List<MqlTick>?> CopyTicksAsync(string symbolName, CopyTicksFlag flags = CopyTicksFlag.All, ulong from = 0, uint count = 0)
+        {
+            Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "Flags", flags },
+                { "From", from }, { "Count", count }  };
+            var response = await SendCommandAsync<List<MtTick>>(ExecutorHandle, Mt5CommandType.CopyTicks, cmdParams).ConfigureAwait(false);
+            return response?.Select(t => new MqlTick(t)).ToList();
+        }
+
+        ///<summary>
         ///The function returns the handle of a specified technical indicator created based on the array of parameters of MqlParam type.
         ///</summary>
         ///<param name="symbol">Name of a symbol, on data of which the indicator is calculated. NULL means the current symbol.</param>
@@ -1584,6 +1682,17 @@ namespace MtApi5
         }
 
         ///<summary>
+        ///Asynchronous variant of SymbolInfoDouble; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="symbolName">Symbol name.</param>
+        ///<param name="propId">Identifier of a symbol property.</param>
+        public Task<double> SymbolInfoDoubleAsync(string symbolName, ENUM_SYMBOL_INFO_DOUBLE propId)
+        {
+            Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "PropId", (int)propId } };
+            return SendCommandAsync<double>(ExecutorHandle, Mt5CommandType.SymbolInfoDouble, cmdParams);
+        }
+
+        ///<summary>
         ///Returns the corresponding property of a specified symbol.
         ///</summary>
         ///<param name="symbolName">Symbol name.</param>
@@ -1592,6 +1701,17 @@ namespace MtApi5
         {
             Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "PropId", (int)propId } };
             return SendCommand<long>(ExecutorHandle, Mt5CommandType.SymbolInfoInteger, cmdParams);
+        }
+
+        ///<summary>
+        ///Asynchronous variant of SymbolInfoInteger; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="symbolName">Symbol name.</param>
+        ///<param name="propId">Identifier of a symbol property.</param>
+        public Task<long> SymbolInfoIntegerAsync(string symbolName, ENUM_SYMBOL_INFO_INTEGER propId)
+        {
+            Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "PropId", (int)propId } };
+            return SendCommandAsync<long>(ExecutorHandle, Mt5CommandType.SymbolInfoInteger, cmdParams);
         }
 
         ///<summary>
@@ -1643,6 +1763,17 @@ namespace MtApi5
             if (SymbolInfoTick(symbol, out MqlTick? tick))
                 return tick;
             return null;
+        }
+
+        ///<summary>
+        ///Asynchronous variant of SymbolInfoTick; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        ///<param name="symbol">Symbol name.</param>
+        public async Task<MqlTick?> SymbolInfoTickAsync(string symbol)
+        {
+            Dictionary<string, object> cmdParams = new() { { "Symbol", symbol ?? string.Empty } };
+            var response = await SendCommandAsync<FuncResult<MtTick>>(ExecutorHandle, Mt5CommandType.SymbolInfoTick, cmdParams).ConfigureAwait(false);
+            return response != null && response.RetVal && response.Result != null ? new MqlTick(response.Result) : null;
         }
 
         ///<summary>
@@ -3159,6 +3290,15 @@ namespace MtApi5
         }
 
         ///<summary>
+        ///Asynchronous variant of TimeCurrent; multiple in-flight commands are pipelined and typically served in a single expert wake-up.
+        ///</summary>
+        public async Task<DateTime> TimeCurrentAsync()
+        {
+            var response = await SendCommandAsync<long>(ExecutorHandle, Mt5CommandType.TimeCurrent).ConfigureAwait(false);
+            return Mt5TimeConverter.ConvertFromMtTime(response);
+        }
+
+        ///<summary>
         ///Returns the calculated current time of the trade server. Unlike TimeCurrent(), the calculation of the time value is performed in the client terminal and depends on the time settings on your computer.
         ///</summary>
         public DateTime TimeTradeServer()
@@ -3621,6 +3761,44 @@ namespace MtApi5
             if (response.ErrorCode != 0)
             {
                 Log.Warn($"SendCommand: ErrorCode = {response.ErrorCode}. {response.ErrorMessage}");
+                throw new ExecutionException((ErrorCode)response.ErrorCode, response.ErrorMessage);
+            }
+
+            return (response.Value == null) ? default : response.Value;
+        }
+
+        private async Task<T?> SendCommandAsync<T>(int expertHandle, Mt5CommandType commandType, object? payload = null)
+        {
+            var client = Client;
+            if (client == null)
+            {
+                Log.Warn("SendCommandAsync: No connection");
+                throw new Exception("No connection");
+            }
+
+            var payloadJson = payload == null ? string.Empty : JsonConvert.SerializeObject(payload);
+            Log.Debug($"SendCommandAsync: sending '{payloadJson}' ...");
+
+            var responseJson = await client.SendCommandAsync(expertHandle, (int)commandType, payloadJson, CommandTimeout).ConfigureAwait(false);
+
+            Log.Debug($"SendCommandAsync: received response JSON [{responseJson}]");
+
+            if (string.IsNullOrEmpty(responseJson))
+            {
+                Log.Warn("SendCommandAsync: Response JSON from MetaTrader is null or empty");
+                throw new ExecutionException(ErrorCode.ErrCustom, "Response from MetaTrader is null");
+            }
+
+            var response = JsonConvert.DeserializeObject<Response<T>>(responseJson);
+            if (response == null)
+            {
+                Log.Warn("SendCommandAsync: Failed to deserialize response from JSON");
+                throw new ExecutionException(ErrorCode.ErrCustom, "Response from MetaTrader is null");
+            }
+
+            if (response.ErrorCode != 0)
+            {
+                Log.Warn($"SendCommandAsync: ErrorCode = {response.ErrorCode}. {response.ErrorMessage}");
                 throw new ExecutionException((ErrorCode)response.ErrorCode, response.ErrorMessage);
             }
 

--- a/MtApi5/MtApi5Client.cs
+++ b/MtApi5/MtApi5Client.cs
@@ -1057,12 +1057,12 @@ namespace MtApi5
         ///<param name="timeframe">Period.</param>
         ///<param name="startPos">The start position for the first element to copy.</param>
         ///<param name="count">Data count to copy.</param>
-        public async Task<MqlRates[]?> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, int startPos, int count)
+        public async Task<MqlRates[]> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, int startPos, int count)
         {
             Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "Timeframe", (int)timeframe },
                 { "StartPos", startPos }, { "Count", count } };
             var response = await SendCommandAsync<List<MqlRates>>(ExecutorHandle, Mt5CommandType.CopyRates, cmdParams).ConfigureAwait(false);
-            return response?.ToArray();
+            return response?.ToArray() ?? [];
         }
 
         ///<summary>
@@ -1089,12 +1089,12 @@ namespace MtApi5
         ///<param name="timeframe">Period.</param>
         ///<param name="startTime">The start time for the first element to copy.</param>
         ///<param name="count">Data count to copy.</param>
-        public async Task<MqlRates[]?> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, DateTime startTime, int count)
+        public async Task<MqlRates[]> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, DateTime startTime, int count)
         {
             Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "Timeframe", (int)timeframe },
                 { "StartTime",  Mt5TimeConverter.ConvertToMtTime(startTime) }, { "Count", count } };
             var response = await SendCommandAsync<List<MqlRates>>(ExecutorHandle, Mt5CommandType.CopyRates1, cmdParams).ConfigureAwait(false);
-            return response?.ToArray();
+            return response?.ToArray() ?? [];
         }
 
         ///<summary>
@@ -1122,13 +1122,13 @@ namespace MtApi5
         ///<param name="timeframe">Period.</param>
         ///<param name="startTime">The start time for the first element to copy.</param>
         ///<param name="stopTime">Bar time, corresponding to the last element to copy.</param>
-        public async Task<MqlRates[]?> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, DateTime startTime, DateTime stopTime)
+        public async Task<MqlRates[]> CopyRatesAsync(string symbolName, ENUM_TIMEFRAMES timeframe, DateTime startTime, DateTime stopTime)
         {
             Dictionary<string, object> cmdParams = new() { { "Symbol", symbolName ?? string.Empty }, { "Timeframe", (int)timeframe },
                 { "StartTime",  Mt5TimeConverter.ConvertToMtTime(startTime) },
                 { "StopTime", Mt5TimeConverter.ConvertToMtTime(stopTime) } };
             var response = await SendCommandAsync<List<MqlRates>>(ExecutorHandle, Mt5CommandType.CopyRates2, cmdParams).ConfigureAwait(false);
-            return response?.ToArray();
+            return response?.ToArray() ?? [];
         }
 
         ///<summary>

--- a/MtClient/MtRpcClient.cs
+++ b/MtClient/MtRpcClient.cs
@@ -87,6 +87,28 @@ namespace MtClient
             return response;
         }
 
+        public async Task<string?> SendCommandAsync(int expertHandle, int commandType, string payload, int timeout = 10000)  // 10 sec
+        {
+            CommandTask<string> commandTask = new();
+            int commandId;
+            lock (tasks_)
+            {
+                commandId = nextCommandId++;
+                tasks_[commandId] = commandTask;
+            }
+
+            MtCommand command = new(expertHandle, commandType, commandId, payload);
+            Send(command);
+
+            var response = await commandTask.WaitResponseAsync(timeout).ConfigureAwait(false);
+            lock (tasks_)
+            {
+                tasks_.Remove(commandId);
+            }
+
+            return response;
+        }
+
         public HashSet<int>? RequestExpertsList()
         {
             CommandTask<object> requestTask = new();
@@ -309,12 +331,29 @@ namespace MtClient
     internal class CommandTask<T>
     {
         private readonly EventWaitHandle responseWaiter_ = new AutoResetEvent(false);
+        // RunContinuationsAsynchronously: the response arrives on the receive thread, so awaiter
+        // continuations must not run inline on it and block processing of further messages.
+        private readonly TaskCompletionSource<T?> responseSource_ = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private T? response_;
         private readonly object locker_ = new();
 
         public T? WaitResponse(int time)
         {
             responseWaiter_.WaitOne(time);
+            lock (locker_)
+            {
+                return response_;
+            }
+        }
+
+        public async Task<T?> WaitResponseAsync(int time)
+        {
+            using var timeoutCancellation = new CancellationTokenSource();
+            var completed = await Task.WhenAny(responseSource_.Task, Task.Delay(time, timeoutCancellation.Token)).ConfigureAwait(false);
+            if (completed == responseSource_.Task)
+                timeoutCancellation.Cancel();
+
+            // Mirrors WaitResponse: on timeout the current response value (default if none arrived) is returned.
             lock (locker_)
             {
                 return response_;
@@ -328,6 +367,7 @@ namespace MtClient
                 response_ = result;
             }
             responseWaiter_.Set();
+            responseSource_.TrySetResult(result);
         }
     }
 

--- a/TestClients/MtApi5TestClient/MainWindow.xaml
+++ b/TestClients/MtApi5TestClient/MainWindow.xaml
@@ -599,6 +599,7 @@
                         <Button Command="{Binding TimeTradeServerCommand}" Content="TimeTradeServer" Margin="2"/>
                         <Button Command="{Binding TimeLocalCommand}" Content="TimeLocal" Margin="2"/>
                         <Button Command="{Binding TimeGMTCommand}" Content="TimeGMT" Margin="2"/>
+                        <Button Command="{Binding AsyncPipelineDemoCommand}" Content="AsyncPipelineDemo" Margin="2"/>
                     </WrapPanel>
                 </TabItem>
 

--- a/TestClients/MtApi5TestClient/ViewModel.cs
+++ b/TestClients/MtApi5TestClient/ViewModel.cs
@@ -1,5 +1,6 @@
 ﻿// ReSharper disable InconsistentNaming
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Windows;
 using MtApi5;
 using System.Collections.ObjectModel;
@@ -112,6 +113,7 @@ namespace MtApi5TestClient
         public DelegateCommand TesterStopCommand { get; private set; }
 
         public DelegateCommand TimeCurrentCommand { get; private set; }
+        public DelegateCommand AsyncPipelineDemoCommand { get; private set; }
 
         public DelegateCommand ChartOpenCommand { get; private set; }
         public DelegateCommand ChartTimePriceToXYCommand { get; private set; }
@@ -488,6 +490,7 @@ namespace MtApi5TestClient
             ChartScreenShotCommand = new DelegateCommand(ExecuteChartScreenShot);
 
             TimeCurrentCommand = new DelegateCommand(ExecuteTimeCurrent);
+            AsyncPipelineDemoCommand = new DelegateCommand(ExecuteAsyncPipelineDemo);
             TimeTradeServerCommand = new DelegateCommand(ExecuteTimeTradeServer);
             TimeLocalCommand = new DelegateCommand(ExecuteTimeLocal);
             TimeGMTCommand = new DelegateCommand(ExecuteTimeGMT);
@@ -1340,6 +1343,52 @@ namespace MtApi5TestClient
         {
             var retVal = await Execute(() => _mtApiClient.TimeCurrent());
             AddLog($"TimeCurrent: {retVal}");
+        }
+
+        private async void ExecuteAsyncPipelineDemo(object o)
+        {
+            const int count = 20;
+
+            try
+            {
+                AddLog($"AsyncPipelineDemo: running {count} sequential sync calls vs {count} concurrent async calls (PositionsTotal/TimeCurrent)...");
+
+                var syncMs = await Task.Run(() =>
+                {
+                    var watch = Stopwatch.StartNew();
+                    for (var i = 0; i < count; i++)
+                    {
+                        if (i % 2 == 0)
+                            _mtApiClient.PositionsTotal();
+                        else
+                            _mtApiClient.TimeCurrent();
+                    }
+                    watch.Stop();
+                    return watch.ElapsedMilliseconds;
+                });
+
+                var asyncWatch = Stopwatch.StartNew();
+                var tasks = new List<Task>(count);
+                for (var i = 0; i < count; i++)
+                {
+                    if (i % 2 == 0)
+                        tasks.Add(_mtApiClient.PositionsTotalAsync());
+                    else
+                        tasks.Add(_mtApiClient.TimeCurrentAsync());
+                }
+                await Task.WhenAll(tasks);
+                asyncWatch.Stop();
+
+                AddLog($"AsyncPipelineDemo: {count} sequential sync calls - {syncMs} ms; {count} concurrent async calls - {asyncWatch.ElapsedMilliseconds} ms");
+            }
+            catch (ExecutionException ex)
+            {
+                AddLog($"AsyncPipelineDemo: Exception: {ex.ErrorCode} - {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                AddLog($"AsyncPipelineDemo: Exception: {ex.Message}");
+            }
         }
 
         private async void ExecuteTimeTradeServer(object o)


### PR DESCRIPTION
## Summary

The RPC core already supports multiple in-flight commands (responses are correlated by `commandId`, and the expert drains its whole command queue per wake-up), but the public API is strictly synchronous — one blocked thread per outstanding command. This PR adds a first-class async path so callers can pipeline requests:

- **MtClient**: `CommandTask` gains a `TaskCompletionSource` (created with `RunContinuationsAsynchronously` — continuations never run inline on the receive thread); new `Task<string?> SendCommandAsync(...)` mirrors `SendCommand`'s registration, locking, and timeout semantics exactly. Purely additive — MT4's `MtApiClient` compiles untouched (verified).
- **MtApi5**: private `SendCommandAsync<T>` mirrors `SendCommand<T>` exception semantics; public async variants for the read-heavy hot set: `PositionsTotalAsync`, `OrdersTotalAsync`, `AccountInfoDouble/IntegerAsync`, `SymbolInfoTickAsync`, `SymbolInfoDouble/IntegerAsync`, `CopyRatesAsync` (3 overloads, returning `Task<MqlRates[]>` directly instead of out params), `CopyTicksAsync`, `TimeCurrentAsync`.
- **Test client**: `AsyncPipelineDemo` action comparing 20 sequential sync calls vs 20 concurrent async calls.

No async variants for trade operations by design — `OrderSendAsync` already exists as a synchronous wrapper of MQL5's `OrderSendAsync` command and a `Task`-returning overload of that name would be a foot-gun.

## Implementation notes

- Timeout semantics mirror sync exactly, including the benign race where a response arriving between timeout expiry and lock acquisition is still returned.
- All library awaits use `ConfigureAwait(false)`; no `async void` in library code.
- `CopyRatesAsync` returns `[]` (never null) on a null response, matching the observable behavior of the sync overloads (review finding, fixed in c236352b).

## Testing

- All four projects build clean (`MtClient`, `MtApi5`, `MtApi` — proving the MT4 surface untouched — and the test client).
- Adversarial review traced deadlock/lock-ordering, task-leak, unobserved-exception, and semantics-parity concerns — no confirmed defects beyond the `CopyRatesAsync` null/empty drift, which is fixed.
- **Runtime-verified against a live MT5 terminal (build 5830):**
  - Correctness: `PositionsTotalAsync`/`TimeCurrentAsync` results equal their sync counterparts.
  - Pipelining: 20 concurrent async commands complete in **102 ms vs 1997 ms** for 20 sequential sync calls against an expert on a 100 ms polling timer (**x19.6**) — all 20 served in a single wake-up, as designed. Against a nudge-responsive expert: 5 ms vs 27 ms (x5.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
